### PR TITLE
Fix datasource configuration and search endpoint

### DIFF
--- a/src/main/java/pl/mr/springTest/HelloWorld.java
+++ b/src/main/java/pl/mr/springTest/HelloWorld.java
@@ -32,10 +32,10 @@ public class HelloWorld {
     }
 
     @RequestMapping(value = "/search/{surname}", method = RequestMethod.GET)
-    public String getCustomers(@PathVariable("surname") String name) {
+    public String getCustomers(@PathVariable("surname") String surname) {
         return StringUtils.join(
                 customerRepository
-                        .findBySurname(name)
+                        .findBySurname(surname)
                         .stream()
                         .map(Customer::getName)
                         .collect(Collectors.toList()),

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,1 +1,1 @@
-spring.datasource.url= jdbc:postgresql://postgres:5432/postgres
+spring.datasource.url=jdbc:postgresql://postgres:5432/postgres

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,1 +1,1 @@
-spring.datasource.url= jdbc:postgresql://postgres.docker.localhost:5432/postgres
+spring.datasource.url=jdbc:postgresql://postgres.docker.localhost:5432/postgres

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url= jdbc:postgresql://localhost:5432/postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- clean up whitespace in database configs
- fix the search endpoint to use the correct path variable

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851d36a665c8326ad9013c2c3ff03fa