### PR TITLE
Add endpoints for image upload and retrieval

### DIFF
--- a/src/main/java/pl/mr/springTest/Image.java
+++ b/src/main/java/pl/mr/springTest/Image.java
@@ -1,0 +1,19 @@
+package pl.mr.springTest;
+
+import lombok.Data;
+
+import javax.persistence.*;
+
+@Data
+@Entity
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String fileName;
+
+    @Lob
+    @Column(columnDefinition = "bytea")
+    private byte[] data;
+}

--- a/src/main/java/pl/mr/springTest/ImageController.java
+++ b/src/main/java/pl/mr/springTest/ImageController.java
@@ -1,0 +1,32 @@
+package pl.mr.springTest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+public class ImageController {
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    @PostMapping("/images")
+    public Long uploadImage(@RequestParam("file") MultipartFile file) throws IOException {
+        Image image = new Image();
+        image.setFileName(file.getOriginalFilename());
+        image.setData(file.getBytes());
+        image = imageRepository.save(image);
+        return image.getId();
+    }
+
+    @GetMapping(value = "/images/{id}", produces = MediaType.IMAGE_JPEG_VALUE)
+    public ResponseEntity<byte[]> getImage(@PathVariable Long id) {
+        return imageRepository.findById(id)
+                .map(img -> ResponseEntity.ok().contentType(MediaType.IMAGE_JPEG).body(img.getData()))
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/pl/mr/springTest/ImageRepository.java
+++ b/src/main/java/pl/mr/springTest/ImageRepository.java
@@ -1,0 +1,6 @@
+package pl.mr.springTest;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ImageRepository extends CrudRepository<Image, Long> {
+}


### PR DESCRIPTION
## Summary
- create `Image` JPA entity
- add `ImageRepository`
- add `ImageController` with endpoints to upload and fetch JPEG images

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851d3e984148326a37d32db6dec429c